### PR TITLE
Updated setup.py to make sanic-restplus installable

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ long_description = '\n'.join((
 ))
 
 
-exec(compile(open('flask_restplus/__about__.py').read(), 'flask_restplus/__about__.py', 'exec'))
+exec(compile(open('sanic_restplus/__about__.py').read(), 'sanic_restplus/__about__.py', 'exec'))
 
 tests_require = ['pytest', 'pytest-sugar', 'pytest-flask', 'pytest-mock', 'pytest-faker', 'blinker', 'tzlocal', 'mock']
 install_requires = ['Sanic>=0.4.1', 'sanic-jinja2', 'six>=1.3.0', 'pytz', 'aniso8601>=0.82', 'jsonschema']
@@ -58,11 +58,11 @@ except:
     tests_require += ['mock']
 
 setup(
-    name='flask-restplus',
+    name='sanic-restplus',
     version=__version__,
     description=__description__,
     long_description=long_description,
-    url='https://github.com/noirbizarre/flask-restplus',
+    url='https://github.com/ashleysommer/sanic-restplus',
     author='Axel Haustant',
     author_email='axel@data.gouv.fr',
     packages=find_packages(exclude=['tests', 'tests.*']),


### PR DESCRIPTION
Offtopic:

I have just thought "what if there will be Flask-RESTplus for Sanic", and bumped right into this project! Great initiative!

I have used the example app from the README (changed `debug=True` to `debug=False`) to see the performance gain and it is great! Here are the results I see on `GET /todos/` (`wrk -c 20 -t20 --latency -d 20 -H 'Accept: application/json'  http://127.0.0.1:5000/todos/`):

* Flask-RESTplus performed 801 req/second
* Sanic-RESTplus performed 1585 req/second

It is almost twice as fast with minimal changes to the code! Yeah, things like SQLAlchemy will make things a bit more complicated as they don't yet support async, but it is still a great starting point.

P.S. Please, consider enabling "Issues" for the project.