### PR TITLE
Use .json property to get request content instead of get_json()

### DIFF
--- a/sanic_restplus/resource.py
+++ b/sanic_restplus/resource.py
@@ -118,7 +118,7 @@ class Resource(MethodViewExt, metaclass=ResourceMeta):
         expected, True if a collection of objects of a resource is expected.
         '''
         # TODO: proper content negotiation
-        data = request.get_json()
+        data = request.json
         if collection:
             data = data if isinstance(data, list) else [data]
             for obj in data:


### PR DESCRIPTION
.get_json() is undefined for Request objects in Sanic.