### PR TITLE
New sanic versions have moved CIMultiDict to a different module

### DIFF
--- a/sanic_restplus/reqparse.py
+++ b/sanic_restplus/reqparse.py
@@ -2,7 +2,6 @@
 #
 import decimal
 import six
-from sanic.server import CIMultiDict
 from sanic import exceptions
 from collections import Hashable
 from copy import deepcopy
@@ -11,6 +10,11 @@ from .errors import abort, SpecsError
 from .marshalling import marshal
 from .model import Model
 from ._http import HTTPStatus
+
+try:
+    from sanic.compat import CIMultiDict
+except ImportError:
+    from sanic.server import CIMultiDict
 
 
 class ParseResult(dict):


### PR DESCRIPTION
Sanic commit:

https://github.com/huge-success/sanic/commit/b397637bb979566183116b2663ec2c1ef02246a9