### PR TITLE
One letter in dictionary:value fixing / reqparse fixing

### DIFF
--- a/sanic_restplus/reqparse.py
+++ b/sanic_restplus/reqparse.py
@@ -131,7 +131,7 @@ class Argument(object):
                 if callable(value):
                     value = value()
                 if value is not None:
-                    values.update(CIMultiDict([(k,a) for k,v in value.items() for a in v]))
+                    values.update(CIMultiDict(value.items()))
             return values
 
         return CIMultiDict()


### PR DESCRIPTION
When you parse a request, it turns out that the result is a dictionary of the form 
```
{
    "key": "v",
}
```

although there was a dictionary 
```
{
    "key": "value",
}
```
 in the request.

---

Replacing `[(k,a) for k,v in value.items() for a in v]` on simple `values.items()` in `CIMultiDict(...)` should help.