### PR TITLE
Requires version_prefix in FutureRoute

### DIFF
--- a/sanic_restplus/api.py
+++ b/sanic_restplus/api.py
@@ -26,6 +26,7 @@ from sanic.helpers import STATUS_CODES
 from sanic.handlers import ErrorHandler
 from sanic.exceptions import SanicException, InvalidUsage, NotFound
 from sanic import exceptions, Sanic, Blueprint
+from sanic.models.futures import FutureRoute as FutureRouteActual
 from sanic.base import BaseSanic
 try:
     from sanic.compat import Header
@@ -356,6 +357,8 @@ class Api(object):
         route_kwargs.setdefault('stream', False)
         route_kwargs.setdefault('name', None)
         route_kwargs.setdefault('version', None)
+        if hasattr(FutureRouteActual, 'version_prefix'):
+            route_kwargs.setdefault('version_prefix', None)
         route_kwargs.setdefault('ignore_body', False)
         route_kwargs.setdefault('websocket', False)
         route_kwargs.setdefault('subprotocols', None)
@@ -442,6 +445,9 @@ class Api(object):
             kwargs.setdefault('stream', False)
             kwargs.setdefault('name', None)
             kwargs.setdefault('version', None)
+            if hasattr(FutureRouteActual, 'version_prefix'):
+                kwargs.setdefault('version_prefix', None)
+
             kwargs.setdefault('ignore_body', False)
             kwargs.setdefault('websocket', False)
             kwargs.setdefault('subprotocols', None)


### PR DESCRIPTION
PR https://github.com/sanic-org/sanic/pull/2137 added a new route requirement of `version_prefix` This patch fixes the API so that it supplies that value if the `FutureRoute` has the attribute.
It is also backwards compatble.